### PR TITLE
Allow empty string for raygun key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var pkg = require("../package.json");
 
 
 var optionsSchema = Joi.object({
-  apiKey: Joi.string(),
+  apiKey: Joi.string().allow(""),
   tags: Joi.array(),
   log: Joi.boolean(),
   user: Joi.func(),
@@ -80,7 +80,7 @@ exports.register = function (server, options, next) {
     // if apiKey not set, don't register plugin
     return next();
   }
-  
+
   var client = new Raygun.Client().init({
     apiKey: config.apiKey
   });


### PR DESCRIPTION
This allows for `undefined` or `""` to be passed in for `apiKey` and then hit the no-op block.